### PR TITLE
Change PIP_MIRROR_URL to Tsinghua mirror

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run plugin repackaging script
         run: |
-          PIP_MIRROR_URL=https://pypi.org/simple \
+          PIP_MIRROR_URL=https://pypi.tuna.tsinghua.edu.cn/simple \
           ./plugin_repackaging.sh \
           -p ${{ env.PIP_PLATFORM }} \
           -s ${{ env.PACKAGE_SUFFIX }} \


### PR DESCRIPTION
Updated PIP_MIRROR_URL to use Tsinghua mirror for package installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved dependency resolution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->